### PR TITLE
Make ltotape for Linux buildable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,14 +2,23 @@ ACLOCAL_AMFLAGS = -I m4
 
 nobase_pkginclude_HEADERS = config.h
 
+GEN_DRV =
+PLAT_DRV =
+
 if PLATFORM_LINUX
-SUBDIRS = messages src/tape_drivers/linux/ltotape
+  PLAT_DRV += src/tape_drivers/linux/ltotape
 endif
 
 if PLATFORM_MAC
-SUBDIRS = messages src/tape_drivers/osx/ltotape
+  PLAT_DRV += src/tape_drivers/osx/ltotape
 endif
 
 if PLATFORM_NETBSD
-SUBDIRS = messages src/tape_drivers/netbsd/ltotape
+  PLAT_DRV += src/tape_drivers/netbsd/ltotape
+endif
+
+if CHECKONLY
+  SUBDIRS = messages src/tape_drivers/generic/dummy
+else
+  SUBDIRS = messages ${GEN_DRV} ${PLAT_DRV}
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -5,14 +5,31 @@ AC_PREREQ([2.69])
 AC_INIT([ltfs-plugins], [0.1], [manu@netbsd.org])
 AC_CONFIG_SRCDIR([src/tape_drivers/netbsd/ltotape/ltotape.c])
 AC_CONFIG_MACRO_DIRS([m4])
-AC_CONFIG_MACRO_DIR([m4]) 
+AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
+AC_PROG_CC_C99
+AM_PROG_CC_C_O
 AM_PROG_AR
 AC_PROG_LIBTOOL
 
+# Detecting target OS
+case "${target_os}" in
+    linux*)
+        target_linux=yes
+        ;;
+    darwin*)
+        target_mac=yes
+        ;;
+    netbsd*)
+        target_netbsd=yes
+        ;;
+    *)
+        AC_MSG_ERROR(["OS $target_os is not supported"])
+        ;;
+esac
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h inttypes.h stdlib.h string.h sys/file.h sys/ioctl.h unistd.h])
@@ -28,15 +45,15 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 AC_CHECK_FUNCS([memset strerror strstr])
 
-dnl  
+dnl
 dnl Check for pkg-config
-dnl 
-if test -z "$PKG_CONFIG" 
+dnl
+if test -z "$PKG_CONFIG"
 then
-    AC_PATH_PROG(PKG_CONFIG, pkg-config, [no]) 
-fi  
+    AC_PATH_PROG(PKG_CONFIG, pkg-config, [no])
+fi
 if test "x${PKG_CONFIG}" = "xno"
-then   
+then
     AC_MSG_ERROR([pkg-config was not found])
 fi
 
@@ -48,13 +65,13 @@ if test "x${GENRB}" = "xno"
 then
     AC_MSG_ERROR([genrb was not found])
 fi
-  
-dnl 
+
+dnl
 dnl Check for pkgdata
-dnl 
+dnl
 AC_PATH_PROG(PKGDATA, pkgdata, no)
 if test "x${PKGDATA}" = "xno"
-then          
+then
     AC_MSG_ERROR([pkgdata was not found])
 fi
 
@@ -88,6 +105,17 @@ then
 fi
 
 dnl
+dnl interface checker
+dnl
+AC_MSG_CHECKING([No driver build, only check backend I/F])
+AC_ARG_ENABLE([checkonly],
+    [AS_HELP_STRING([--enable-checkonly],[No driver build, only check backend I/F])],
+    [checkonly=$enableval],
+    [checkonly=no]
+)
+AC_MSG_RESULT([$checkonly])
+
+dnl
 dnl test for ENOMEDIUM
 dnl
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <errno.h>],[
@@ -95,39 +123,30 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <errno.h>],[
 #error no ENOMEDIUM
 #endif])],[],[AM_CPPFLAGS="${AM_CPPFLAGS} -DENOMEDIUM=EAGAIN"])
 
+if test "x${target_linux}" = "xyes"
+then
+    AM_CPPFLAGS="-D_GNU_SOURCE"
+fi
 
 AM_CPPFLAGS="${AM_CPPFLAGS} `${PKG_CONFIG} --cflags ltfs`"
 AM_CPPFLAGS="${AM_CPPFLAGS} `${PKG_CONFIG} --cflags fuse`"
 AM_CPPFLAGS="${AM_CPPFLAGS} -DIBM_LTFS_BUILD -DGENERIC_OEM_BUILD"
 AM_CPPFLAGS="${AM_CPPFLAGS} ${ICU_MODULE_CFLAGS}"
 
-case "${target_os}" in
-    linux*)
-	target_linux=yes
-        ;;
-    darwin*)
-        host_mac=yes
-        ;;
-    netbsd*)
-        target_netbsd=yes
-        ;;
-    *)
-        AC_MSG_ERROR(["OS $target_os is not supported"])
-        ;;
-esac
-
 AM_CONDITIONAL([PLATFORM_LINUX], [test "x${target_linux}" = "xyes"])
 AM_CONDITIONAL([PLATFORM_MAC], [test "x${target_mac}" = "xyes"])
 AM_CONDITIONAL([PLATFORM_NETBSD], [test "x${target_netbsd}" = "xyes"])
+AM_CONDITIONAL([CHECKONLY], [test "x${checkonly}" = "xyes"])
 AM_CONDITIONAL([CHK_MESSAGE], [test "x${use_msg_check}" = "xyes"])
 
 AC_SUBST(CFLAGS)
 AC_SUBST(AM_CPPFLAGS)
 AC_SUBST(AM_EXTRA_CPPFLAGS)
 AC_SUBST(AM_CFLAGS)
-AC_SUBST(AM_LDFLAGS) 
+AC_SUBST(AM_LDFLAGS)
 
-AC_CONFIG_FILES([Makefile messages/Makefile 
+AC_CONFIG_FILES([Makefile messages/Makefile
+                 src/tape_drivers/generic/dummy/Makefile
                  src/tape_drivers/linux/ltotape/Makefile
                  src/tape_drivers/osx/ltotape/Makefile
                  src/tape_drivers/netbsd/ltotape/Makefile])

--- a/src/tape_drivers/linux/ltotape/Makefile.am
+++ b/src/tape_drivers/linux/ltotape/Makefile.am
@@ -11,7 +11,7 @@
 #  under the terms of version 2.1 of the GNU Lesser General Public License
 #  as published by the Free Software Foundation.
 #
-# This program is distributed in the hope that it will be useful, but 
+# This program is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 #  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
 #  License for more details.
@@ -31,8 +31,8 @@ libdir = @libdir@/ltfs
 AM_LIBTOOLFLAGS = --tag=disable-static
 
 libdriver_ltotape_la_SOURCES = ltotape.c  ltotape_diag.c  ltotape_platform.c
-libdriver_ltotape_la_DEPENDENCIES = $(top_srcdir)/messages/libdriver_ltotape_dat.la
-libdriver_ltotape_la_LIBADD = $(top_srcdir)/messages/libdriver_ltotape_dat.la
+libdriver_ltotape_la_DEPENDENCIES = $(top_srcdir)/messages/libdriver_ltotape_dat.a
+libdriver_ltotape_la_LIBADD = $(top_srcdir)/messages/libdriver_ltotape_dat.a
 libdriver_ltotape_la_CPPFLAGS = @AM_CPPFLAGS@ -I$(top_srcdir)/src
 libdriver_ltotape_la_LDFLAGS = -avoid-version -module
 

--- a/src/tape_drivers/linux/ltotape/ltotape_platform.c
+++ b/src/tape_drivers/linux/ltotape/ltotape_platform.c
@@ -35,7 +35,6 @@
 #include <sys/stat.h>
 #include <sys/file.h>
 #include <scsi/sg.h>
-#include <scsi/scsi.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <string.h>
@@ -46,6 +45,7 @@
 #include "ltotape.h"
 #include "ltotape_diag.h"
 #include "ltotape_supdevs.h"
+#include <scsi/scsi.h>
 
 /*
  * Max transfer size to ask the SG driver to handle (1MB):
@@ -114,7 +114,7 @@ int ltotape_scsiexec (ltotape_scsi_io_type *scsi_io)
 
   memset ((void *)&sg_io, 0, sizeof (sg_io));
 
-  /* 
+  /*
    * Set up required fields
    */
   sg_io.interface_id    = (int) 'S';
@@ -138,12 +138,12 @@ int ltotape_scsiexec (ltotape_scsi_io_type *scsi_io)
     free (sense_string);
   }
 
-  /* 
-   * Here's the actual command execution 
+  /*
+   * Here's the actual command execution
    */
   status = ioctl (scsi_io->fd, SG_IO, &sg_io);
 
-  /* 
+  /*
    * Now determine the outcome:
    */
   scsi_status = S_NO_STATUS; /* Until proven otherwise... */
@@ -152,34 +152,34 @@ int ltotape_scsiexec (ltotape_scsi_io_type *scsi_io)
   if ((status < 0) || ((sg_io.driver_status & 0xF) == SG_ERR_DRIVER_INVALID)) {
     driver_status = DS_ILLEGAL;
 
-  /* 
+  /*
    * Unit didn't respond to selection
    */
   } else if (sg_io.host_status == SG_ERR_DID_NO_CONNECT) {
     driver_status = DS_SELECTION_TIMEOUT;
 
-  /* 
+  /*
    * Unit timed out
    */
   } else if (sg_io.host_status == SG_ERR_DID_TIME_OUT) {
     driver_status = DS_TIMEOUT;
     errno = ETIMEDOUT;
 
-  /* 
+  /*
    * Bus (link, whatever) was reset
    */
   } else if (sg_io.host_status == SG_ERR_DID_RESET) {
     driver_status = DS_RESET;
     if (errno == 0) errno = EIO; /* ensure it doesn't go unnoticed */
 
-  /* 
-   * Good driver status 
+  /*
+   * Good driver status
    */
   } else if (sg_io.host_status == SG_ERR_DID_OK) {
     driver_status = DS_GOOD;
     scsi_status = sg_io.status;
 
-  /* 
+  /*
    * For anything else, create a composite value of "driver status" to help with debug
    */
   } else
@@ -188,7 +188,7 @@ int ltotape_scsiexec (ltotape_scsi_io_type *scsi_io)
   scsi_io->actual_data_length     = sg_io.dxfer_len - sg_io.resid;
   scsi_io->sense_length           = sg_io.sb_len_wr;
 
-  /* 
+  /*
    * A driver error is always bad news
    */
   if (driver_status != DS_GOOD) {
@@ -316,28 +316,28 @@ int ltotape_map_st2sg (const char *devname, char *sgdevname)
     int host_unique_id;
   } devinfo;
 
-  /* 
+  /*
    * First check for a valid device name:
    */
   if (devname == (const char *)NULL) {
     ltfsmsg (LTFS_ERR, "20032E", devname, "Null device name");
     return -EDEV_INVALID_ARG;
-   
-  /* 
+
+  /*
    * If the given device is already a 'sg' device, nothing to be done.
    */
   } else if (strstr (devname, "/dev/sg") != (char*)NULL) {
     strcpy (sgdevname, devname);
     return DEVICE_GOOD;
-   
-  /* 
+
+  /*
    * If the given device is a 'st' device, change it to an 'nst' device to ensure that
    * on close the driver doesn't issue a rewind command to the tape.
    */
   } else if (strstr (devname, "/dev/st") != (char *)NULL) {
     length = strlen (devname) + 2; /* +1 for 'n' and +1 for '\0' */
     outcome = asprintf (&temp, "%s", devname + strlen ("/dev/st"));
-    
+
     if ((outcome == -1) || (!temp)) {   /* Low on memory or other error. Return failure. */
       ltfsmsg (LTFS_ERR, "20100E");
       sgdevname = NULL;
@@ -348,7 +348,7 @@ int ltotape_map_st2sg (const char *devname, char *sgdevname)
     if (!nstdevname) {      /* Low on memory. Return failure. */
       ltfsmsg (LTFS_ERR, "20100E");
       if (temp) {
-        free (temp); 
+        free (temp);
         temp = NULL;
       }
       sgdevname = NULL;
@@ -366,9 +366,9 @@ int ltotape_map_st2sg (const char *devname, char *sgdevname)
       temp = NULL;
     }
 
-  /* 
+  /*
    * Given device name is already a 'nst' device; or if 'something else' (/dev/something) is
-   * passed by the user, 'open' should handle that below. 
+   * passed by the user, 'open' should handle that below.
    */
   } else {
     nstdevname = (char *)devname;
@@ -391,7 +391,7 @@ int ltotape_map_st2sg (const char *devname, char *sgdevname)
     if (outcome < 0) {
       ltfsmsg (LTFS_ERR, "20032E", devname, "SCSI_IOCTL_GET_IDLUN failed");
       if (allocated) {
-        free (nstdevname); 
+        free (nstdevname);
         nstdevname = NULL;
       }
       return -EDEV_DRIVER_ERROR;
@@ -399,7 +399,7 @@ int ltotape_map_st2sg (const char *devname, char *sgdevname)
     } else if ((fp = fopen ("/proc/scsi/sg/devices", "rb")) == (FILE *)NULL) {
       ltfsmsg (LTFS_ERR, "20032E", devname, "Unable to open /proc/scsi/sg/devices");
       if (allocated) {
-        free (nstdevname); 
+        free (nstdevname);
         nstdevname = NULL;
       }
       return -EDEV_INTERNAL_ERROR;
@@ -424,7 +424,7 @@ int ltotape_map_st2sg (const char *devname, char *sgdevname)
 
       if (!found) {
         if (allocated) {
-          free (nstdevname); 
+          free (nstdevname);
           nstdevname = NULL;
         }
         return -EDEV_DEVICE_UNSUPPORTABLE;
@@ -433,7 +433,7 @@ int ltotape_map_st2sg (const char *devname, char *sgdevname)
         sprintf (sgdevname, "/dev/sg%d", i);
         ltfsmsg (LTFS_DEBUG, "20034D", nstdevname, sgdevname, dev_host_no, dev_channel, dev_scsi_id, dev_lun);
         if (allocated) {
-          free (nstdevname); 
+          free (nstdevname);
           nstdevname = NULL;
         }
         return DEVICE_GOOD;
@@ -463,7 +463,7 @@ int ltotape_open (const char *devname, void **handle)
 
   memset (&inq_data, 0, sizeof (struct tc_inq));
 
-  /* 
+  /*
    * We use the SCSI generic driver for ioctls. Here we attempt to map a given 'st' device
    * to a corresponding 'sg' device...
    */
@@ -479,7 +479,7 @@ int ltotape_open (const char *devname, void **handle)
     return -EDEV_NO_MEMORY;
   }
 
-  /* 
+  /*
    * Open the device:
    */
   device->fd = open (sgdevname, O_RDWR | O_NDELAY);
@@ -489,7 +489,7 @@ int ltotape_open (const char *devname, void **handle)
       if (errno == EAGAIN) {
         ltfsmsg (LTFS_ERR, "20086E", devname);
         ret = -EDEV_DEVICE_BUSY;
-  
+
       } else {
         ltfsmsg (LTFS_ERR, "20087E", devname, errno);
         ret = -EDEV_DEVICE_UNOPENABLE;
@@ -500,7 +500,7 @@ int ltotape_open (const char *devname, void **handle)
     ltfsmsg (LTFS_WARN, "20088W", devname);
   }
 
-  /* 
+  /*
    * Lock the opened device.
    */
   if (flock (device->fd, LOCK_EX | LOCK_NB) != 0) {
@@ -518,17 +518,17 @@ int ltotape_open (const char *devname, void **handle)
   ioctl (device->fd, SG_GET_RESERVED_SIZE, &res_sz);
   ltfsmsg (LTFS_DEBUG, "20020D", res_sz);
 
-  /* 
+  /*
    * Set up the default timeout, should be overwritten by each backend function:
    */
   device->timeout_ms = LTO_DEFAULT_TIMEOUT;
 
-  /* 
+  /*
    * Default Early Warning EOM state is that we're not yet at the warning point:
    */
   device->eweomstate = before_eweom;
 
-  /* 
+  /*
    * Default logfile directory - initially NULL; will get set if/when we parse FUSE options..
    */
   device->logdir = NULL;


### PR DESCRIPTION
  - Make ltotape backend for Linux buildable
  - Add --enable-checkonly build for detecting build break because of
    the backend I/F change in the LTFS project (May be checked by
    Travis CI on the LTFS project)
  - Add .gitignore to ignore some files created by the autotools

See PR #2 for additional discussions.