### PR TITLE
Support new I/F get_info()

### DIFF
--- a/src/tape_drivers/generic/dummy/dummy.c
+++ b/src/tape_drivers/generic/dummy/dummy.c
@@ -342,6 +342,11 @@ int dummy_get_serialnumber(void *device, char **result)
 	return DEVICE_GOOD;
 }
 
+static int dummy_get_info(void *device, struct tc_drive_info *info)
+{
+	return DEVICE_GOOD;
+}
+
 int dummy_set_profiler(void *device, char *work_dir, bool enable)
 {
 	/* Do nohting: file backend does not support profiler */
@@ -404,6 +409,7 @@ struct tape_ops dummy_handler = {
 	.is_mountable           = dummy_is_mountable,
 	.get_worm_status        = dummy_get_worm_status,
 	.get_serialnumber       = dummy_get_serialnumber,
+	.get_info               = dummy_get_info,
 	.set_profiler           = dummy_set_profiler,
 	.get_block_in_buffer    = dummy_get_block_in_buffer,
 	.is_readonly            = dummy_is_readonly,

--- a/src/tape_drivers/linux/ltotape/ltotape_compat.c
+++ b/src/tape_drivers/linux/ltotape/ltotape_compat.c
@@ -47,6 +47,13 @@ ltotape_get_serialnumber(void *device, char **result)
 }
 
 static int
+ltotape_get_info(void *device, struct tc_drive_info *info)
+{
+	/* Do nothing at this time */
+	return 0;
+}
+
+static int
 ltotape_set_profiler(void *device, char *work_dir, bool enable)
 {
 	printf("uninmplemente\n");
@@ -720,6 +727,7 @@ struct tape_ops ltotape_drive_handler = {
         .is_mountable           = _ltotape_is_mountable,
         .get_worm_status        = ltotape_wrapper_get_worm_status,
 	.get_serialnumber       = ltotape_get_serialnumber,
+	.get_info               = ltotape_get_info,
 	.set_profiler           = ltotape_set_profiler,
 	.get_block_in_buffer    = ltotape_get_block_in_buffer,
 	.is_readonly            = ltotape_is_readonly,

--- a/src/tape_drivers/netbsd/ltotape/ltotape_compat.c
+++ b/src/tape_drivers/netbsd/ltotape/ltotape_compat.c
@@ -47,6 +47,13 @@ ltotape_get_serialnumber(void *device, char **result)
 }
 
 static int
+ltotape_get_info(void *device, struct tc_drive_info *info)
+{
+	/* Do nothing at this time */
+	return 0;
+}
+
+static int
 ltotape_set_profiler(void *device, char *work_dir, bool enable)
 {
 	printf("uninmplemente\n");
@@ -720,6 +727,7 @@ struct tape_ops ltotape_drive_handler = {
         .is_mountable           = _ltotape_is_mountable,
         .get_worm_status        = ltotape_wrapper_get_worm_status,
 	.get_serialnumber       = ltotape_get_serialnumber,
+	.get_info               = ltotape_get_info,
 	.set_profiler           = ltotape_set_profiler,
 	.get_block_in_buffer    = ltotape_get_block_in_buffer,
 	.is_readonly            = ltotape_is_readonly,

--- a/src/tape_drivers/osx/ltotape/ltotape_compat.c
+++ b/src/tape_drivers/osx/ltotape/ltotape_compat.c
@@ -47,6 +47,13 @@ ltotape_get_serialnumber(void *device, char **result)
 }
 
 static int
+ltotape_get_info(void *device, struct tc_drive_info *info)
+{
+	/* Do nothing at this time */
+	return 0;
+}
+
+static int
 ltotape_set_profiler(void *device, char *work_dir, bool enable)
 {
 	printf("uninmplemente\n");
@@ -720,6 +727,7 @@ struct tape_ops ltotape_drive_handler = {
         .is_mountable           = _ltotape_is_mountable,
         .get_worm_status        = ltotape_wrapper_get_worm_status,
 	.get_serialnumber       = ltotape_get_serialnumber,
+	.get_info               = ltotape_get_info,
 	.set_profiler           = ltotape_set_profiler,
 	.get_block_in_buffer    = ltotape_get_block_in_buffer,
 	.is_readonly            = ltotape_is_readonly,


### PR DESCRIPTION
LTFS project is introducing new I/F get_info() into backend I/F for path switch support.

Once this change is introduced into the LTFS project. The build checking might break. So I will make a change to this project in advance. 